### PR TITLE
fix: signal filtering with dbus variant args

### DIFF
--- a/src/dbus2mqtt/dbus/dbus_client.py
+++ b/src/dbus2mqtt/dbus/dbus_client.py
@@ -124,7 +124,7 @@ class DbusClient:
 
                 on_signal_method_name = "on_" + camel_to_snake(signal_config.signal)
                 dbus_signal_state = {
-                    "bus_name_subscriptions": bus_name_subscriptions,
+                    "bus_name": bus_name,
                     "path": path,
                     "interface_name": interface.name,
                     "subscription_config": subscription_config,
@@ -354,6 +354,8 @@ class DbusClient:
 
     async def _handle_on_dbus_signal(self, signal: DbusSignalWithState):
 
+        logger.debug(f"dbus_signal: signal={signal.signal_config.signal}, args={signal.args}, bus_name={signal.bus_name}, path={signal.path}, interface={signal.interface_name}")
+
         for flow in signal.subscription_config.flows:
             for trigger in flow.triggers:
                 if trigger.type == "dbus_signal" and signal.signal_config.signal == trigger.signal:
@@ -366,7 +368,7 @@ class DbusClient:
 
                         if matches_filter:
                             context = {
-                                "bus_name": signal.bus_name_subscriptions.bus_name,
+                                "bus_name": signal.bus_name,
                                 "path": signal.path,
                                 "interface": signal.interface_name,
                                 "args": signal.args

--- a/src/dbus2mqtt/dbus/dbus_util.py
+++ b/src/dbus2mqtt/dbus/dbus_util.py
@@ -15,7 +15,7 @@ def unwrap_dbus_object(o):
     json_obj = json.loads(res)
     return json_obj
 
-def unwrap_dbus_objects(*args):
+def unwrap_dbus_objects(args):
     res = [unwrap_dbus_object(o) for o in args]
     return res
 

--- a/src/dbus2mqtt/event_broker.py
+++ b/src/dbus2mqtt/event_broker.py
@@ -13,7 +13,6 @@ from dbus2mqtt.config import (
     SignalConfig,
     SubscriptionConfig,
 )
-from dbus2mqtt.dbus.dbus_types import BusNameSubscriptions
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +25,7 @@ class MqttMessage:
 
 @dataclass
 class DbusSignalWithState:
-    bus_name_subscriptions: BusNameSubscriptions
+    bus_name: str
     path: str
     interface_name: str
     subscription_config: SubscriptionConfig

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -55,9 +55,15 @@ def mocked_flow_processor(app_context: AppContext, trigger_config: FlowTriggerCo
     processor = FlowProcessor(app_context)
     return processor, flow_config
 
+class MockedMessageBus(dbus_aio.message_bus.MessageBus):
+    def _setup_socket(self):
+        self._stream = ""
+        self._sock = ""
+        self._fd = ""
+
 def mocked_dbus_client(app_context: AppContext):
 
-    bus = dbus_aio.message_bus.MessageBus()
+    bus = MockedMessageBus(bus_address="unix:path=/run/user/1000/bus")
     flow_scheduler = FlowScheduler(app_context)
 
     dbus_client = DbusClient(app_context, bus, flow_scheduler)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,6 @@
 
+import dbus_next.aio as dbus_aio
+
 from pydantic import SecretStr
 
 from dbus2mqtt import AppContext, config
@@ -8,8 +10,9 @@ from dbus2mqtt.config import (
     FlowTriggerConfig,
     InterfaceConfig,
 )
+from dbus2mqtt.dbus.dbus_client import DbusClient
 from dbus2mqtt.event_broker import EventBroker
-from dbus2mqtt.flow.flow_processor import FlowProcessor
+from dbus2mqtt.flow.flow_processor import FlowProcessor, FlowScheduler
 from dbus2mqtt.template.templating import TemplateEngine
 
 
@@ -51,3 +54,11 @@ def mocked_flow_processor(app_context: AppContext, trigger_config: FlowTriggerCo
 
     processor = FlowProcessor(app_context)
     return processor, flow_config
+
+def mocked_dbus_client(app_context: AppContext):
+
+    bus = dbus_aio.message_bus.MessageBus()
+    flow_scheduler = FlowScheduler(app_context)
+
+    dbus_client = DbusClient(app_context, bus, flow_scheduler)
+    return dbus_client

--- a/tests/dbus/test_dbus_client.py
+++ b/tests/dbus/test_dbus_client.py
@@ -1,0 +1,49 @@
+
+import dbus_next.introspection as dbus_intr
+import dbus_next.signature as dbus_signature
+
+from dbus_next.constants import ArgDirection
+
+from tests import mocked_app_context, mocked_dbus_client
+
+
+def test_signal_handler_unwrap_args():
+
+    app_context = mocked_app_context()
+    dbus_client = mocked_dbus_client(app_context)
+
+    dbus_signal = dbus_intr.Signal("PropertiesChanged", [
+        dbus_intr.Arg(name="interface_name", signature="s", direction=[ArgDirection.IN]),
+        dbus_intr.Arg(name="changed_properties", signature="a{sv}", direction=[ArgDirection.IN]),
+        dbus_intr.Arg(name="invalidated_properties", signature="as", direction=[ArgDirection.IN])
+    ])
+
+    dbus_signal_state = {}
+    dbus_signal_state = {
+        "bus_name": "org.mpris.MediaPlayer2.vlc",
+        "path": "/org/mpris/MediaPlayer2",
+        "interface_name": "org.freedesktop.DBus.Properties",
+        "subscription_config": None, # subscription_config,
+        "signal_config": None, # signal_config,
+    }
+
+    handler = dbus_client._dbus_next_signal_handler(dbus_signal, dbus_signal_state)
+    assert handler is not None
+
+    args = [
+        "org.mpris.MediaPlayer2.Player",
+        {
+            "CanPause": dbus_signature.Variant("b", True)
+        },
+        []
+    ]
+
+    # Invoke with wrapped arguments
+    handler(*args)
+
+    # Check if message is published on the event_broker
+    mqtt_message = app_context.event_broker.dbus_signal_queue.sync_q.get_nowait()
+
+    # message args should be unwrapped
+    assert mqtt_message is not None
+    assert mqtt_message.args == ["org.mpris.MediaPlayer2.Player", {"CanPause" : True}, []]

--- a/tests/flow/triggers/test_dbus_client_triggers.py
+++ b/tests/flow/triggers/test_dbus_client_triggers.py
@@ -1,8 +1,5 @@
-
-import dbus_next.aio as dbus_aio
 import pytest
 
-from dbus2mqtt import AppContext
 from dbus2mqtt.config import (
     FlowActionContextSetConfig,
     FlowTriggerBusNameAddedConfig,
@@ -10,10 +7,8 @@ from dbus2mqtt.config import (
     FlowTriggerDbusSignalConfig,
     SignalConfig,
 )
-from dbus2mqtt.dbus.dbus_client import DbusClient
 from dbus2mqtt.event_broker import DbusSignalWithState
-from dbus2mqtt.flow.flow_processor import FlowScheduler
-from tests import mocked_app_context, mocked_flow_processor
+from tests import mocked_app_context, mocked_dbus_client, mocked_flow_processor
 
 
 @pytest.mark.asyncio
@@ -32,7 +27,7 @@ async def test_bus_name_added_trigger():
         )
     ])
 
-    dbus_client = _mocked_dbus_client(app_context)
+    dbus_client = mocked_dbus_client(app_context)
 
     subscription_config = app_context.config.dbus.subscriptions[0]
 
@@ -64,7 +59,7 @@ async def test_bus_name_removed_trigger():
         )
     ])
 
-    dbus_client = _mocked_dbus_client(app_context)
+    dbus_client = mocked_dbus_client(app_context)
 
     subscription_config = app_context.config.dbus.subscriptions[0]
 
@@ -104,7 +99,7 @@ async def test_dbus_signal_trigger():
 
     subscription_config = app_context.config.dbus.subscriptions[0]
 
-    dbus_client = _mocked_dbus_client(app_context)
+    dbus_client = mocked_dbus_client(app_context)
 
     signal = DbusSignalWithState(
         bus_name="test-bus-name",
@@ -132,17 +127,3 @@ async def test_dbus_signal_trigger():
         "interface": "test-interface-name",
         "args": ["first-arg", "second-arg"]
     }
-
-class MockedMessageBus(dbus_aio.message_bus.MessageBus):
-    def _setup_socket(self):
-        self._stream = ""
-        self._sock = ""
-        self._fd = ""
-
-def _mocked_dbus_client(app_context: AppContext):
-
-    bus = MockedMessageBus(bus_address="unix:path=/run/user/1000/bus")
-    flow_scheduler = FlowScheduler(app_context)
-
-    dbus_client = DbusClient(app_context, bus, flow_scheduler)
-    return dbus_client

--- a/tests/flow/triggers/test_dbus_client_triggers.py
+++ b/tests/flow/triggers/test_dbus_client_triggers.py
@@ -11,7 +11,7 @@ from dbus2mqtt.config import (
     SignalConfig,
 )
 from dbus2mqtt.dbus.dbus_client import DbusClient
-from dbus2mqtt.event_broker import BusNameSubscriptions, DbusSignalWithState
+from dbus2mqtt.event_broker import DbusSignalWithState
 from dbus2mqtt.flow.flow_processor import FlowScheduler
 from tests import mocked_app_context, mocked_flow_processor
 
@@ -107,7 +107,7 @@ async def test_dbus_signal_trigger():
     dbus_client = _mocked_dbus_client(app_context)
 
     signal = DbusSignalWithState(
-        bus_name_subscriptions=BusNameSubscriptions("test-bus-name"),
+        bus_name="test-bus-name",
         path="/",
         interface_name=subscription_config.interfaces[0].interface,
         subscription_config=subscription_config,


### PR DESCRIPTION
This was broken due to dbus Variant args not being handled correctly

```yaml
    - signal: PropertiesChanged
      filter: "{{ args[0] == 'org.mpris.MediaPlayer2.Player' }}"
```