### PR TITLE
Workaround stale MRPIS Position data after Seeked signal

### DIFF
--- a/docs/examples/home_assistant_media_player.yaml
+++ b/docs/examples/home_assistant_media_player.yaml
@@ -57,6 +57,9 @@ dbus:
               context:
                 mpris_bus_name: '{{ dbus_list("org.mpris.MediaPlayer2.*") | first }}'
                 mpris_path: /org/mpris/MediaPlayer2
+                # Some players return stale position if GetAll is executed immediately after a seeked signal.
+                # By storing the seeked position it can be used to override Position below
+                seeked_position: '{{ args[0] if trigger_type == "dbus_signal" and signal == "Seeked" else None }}'
             - type: context_set
               context:
                 player_properties: |
@@ -68,6 +71,7 @@ dbus:
                 {{
                     { 'bus_name': mpris_bus_name }
                     | combine(player_properties)
+                    | combine ({ 'Position': seeked_position } if seeked_position else {})
                 }}
 
         - name: "publish local art image"

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -55,6 +55,7 @@ When triggered, the following context parameters are available
 | bus_name  | string | bus_name of the object that was registered on dbus |
 | path      | string | path of the object that was registered on dbus |
 | interface | string | name of interface for which the signal was triggered |
+| signal    | string | name of the signal, e.g. 'Seeked'
 | args      | list   | signal arguments, list of objects |
 
 ### object_added

--- a/src/dbus2mqtt/dbus/dbus_client.py
+++ b/src/dbus2mqtt/dbus/dbus_client.py
@@ -713,6 +713,7 @@ class DbusClient:
                                 "bus_name": signal.bus_name,
                                 "path": signal.path,
                                 "interface": signal.interface_name,
+                                "signal": signal.signal_config.signal,
                                 "args": signal.args
                             }
                             trigger_message = FlowTriggerMessage(

--- a/src/dbus2mqtt/flow/flow_processor.py
+++ b/src/dbus2mqtt/flow/flow_processor.py
@@ -109,13 +109,15 @@ class FlowActionContext:
 
         return res
 
-    async def execute_actions(self, trigger_context: dict[str, Any] | None):
+    async def execute_actions(self, trigger_type: str, trigger_context: dict[str, Any] | None):
 
         # per flow execution context
         context = FlowExecutionContext(
             self.flow_config.name,
             global_flows_context=self.global_flows_context,
             flow_context=self.flow_context)
+
+        context.context["trigger_type"] = trigger_type
 
         if trigger_context:
             context.context.update(trigger_context)
@@ -194,6 +196,7 @@ class FlowProcessor:
 
     async def _process_flow_trigger(self, flow_trigger_message: FlowTriggerMessage):
 
+        trigger_type = flow_trigger_message.flow_trigger_config.type
         trigger_str = self._trigger_config_to_str(flow_trigger_message)
         flow_str = flow_trigger_message.flow_config.name or flow_trigger_message.flow_config.id
 
@@ -207,4 +210,4 @@ class FlowProcessor:
         flow_id = flow_trigger_message.flow_config.id
 
         flow = self._flows[flow_id]
-        await flow.execute_actions(trigger_context=flow_trigger_message.trigger_context)
+        await flow.execute_actions(trigger_type, trigger_context=flow_trigger_message.trigger_context)

--- a/tests/flow/triggers/test_dbus_client_triggers.py
+++ b/tests/flow/triggers/test_dbus_client_triggers.py
@@ -23,6 +23,7 @@ async def test_bus_name_added_trigger():
         FlowActionContextSetConfig(
             global_context={
                 "res": {
+                    "trigger_type": "{{ trigger_type }}",
                     "bus_name": "{{ bus_name }}",
                     "path": "{{ path }}",
                 }
@@ -43,6 +44,7 @@ async def test_bus_name_added_trigger():
 
     # expected context from _trigger_bus_name_added
     assert processor._global_context["res"] == {
+        "trigger_type": "bus_name_added",
         "bus_name": "test-bus-name",
         "path": "/some/test/path",
     }
@@ -57,6 +59,7 @@ async def test_bus_name_removed_trigger():
         FlowActionContextSetConfig(
             global_context={
                 "res": {
+                    "trigger_type": "{{ trigger_type }}",
                     "bus_name": "{{ bus_name }}",
                     "path": "{{ path }}"
                 }
@@ -77,6 +80,7 @@ async def test_bus_name_removed_trigger():
 
     # expected context from _trigger_bus_name_removed
     assert processor._global_context["res"] == {
+        "trigger_type": "bus_name_removed",
         "bus_name": "test-bus-name",
         "path": "/some/test/path",
     }
@@ -91,6 +95,7 @@ async def test_object_added_trigger():
         FlowActionContextSetConfig(
             global_context={
                 "res": {
+                    "trigger_type": "{{ trigger_type }}",
                     "bus_name": "{{ bus_name }}",
                     "path": "{{ path }}",
                 }
@@ -111,6 +116,7 @@ async def test_object_added_trigger():
 
     # expected context from _trigger_object_added
     assert processor._global_context["res"] == {
+        "trigger_type": "object_added",
         "bus_name": "test-bus-name",
         "path": "/some/test/path",
     }
@@ -125,6 +131,7 @@ async def test_object_removed_trigger():
         FlowActionContextSetConfig(
             global_context={
                 "res": {
+                    "trigger_type": "{{ trigger_type }}",
                     "bus_name": "{{ bus_name }}",
                     "path": "{{ path }}"
                 }
@@ -145,6 +152,7 @@ async def test_object_removed_trigger():
 
     # expected context from _trigger_object_removed
     assert processor._global_context["res"] == {
+        "trigger_type": "object_removed",
         "bus_name": "test-bus-name",
         "path": "/some/test/path",
     }
@@ -163,9 +171,11 @@ async def test_dbus_signal_trigger():
         FlowActionContextSetConfig(
             global_context={
                 "res": {
+                    "trigger_type": "{{ trigger_type }}",
                     "bus_name": "{{ bus_name }}",
                     "path": "{{ path }}",
                     "interface": "{{ interface }}",
+                    "signal": "{{ signal }}",
                     "args": "{{ args }}"
                 }
             }
@@ -200,8 +210,10 @@ async def test_dbus_signal_trigger():
 
     # validate results
     assert processor._global_context["res"] == {
+        "trigger_type": "dbus_signal",
         "bus_name": bus_name,
         "path": "/",
         "interface": "test-interface-name",
+        "signal": "TestSignal",
         "args": ["first-arg", "second-arg"]
     }


### PR DESCRIPTION
After a Seeked signal, GetAll returns the old seeked position for a short moment. This PR works around that by using the Position provided in the signal payload itself