### PR TITLE
Configurable topics for responses to method calls and Variant Handling for SetProperty

### DIFF
--- a/src/dbus2mqtt/config/__init__.py
+++ b/src/dbus2mqtt/config/__init__.py
@@ -32,7 +32,7 @@ class PropertyConfig:
 class InterfaceConfig:
     interface: str
     mqtt_command_topic: str | None = None
-    mqtt_response_topic: str | None = None  # NEW: Response topic template
+    mqtt_response_topic: str | None = None
     signals: list[SignalConfig] = field(default_factory=list)
     methods: list[MethodConfig] = field(default_factory=list)
     properties: list[PropertyConfig] = field(default_factory=list)

--- a/src/dbus2mqtt/config/__init__.py
+++ b/src/dbus2mqtt/config/__init__.py
@@ -32,6 +32,7 @@ class PropertyConfig:
 class InterfaceConfig:
     interface: str
     mqtt_command_topic: str | None = None
+    mqtt_response_topic: str | None = None  # NEW: Response topic template
     signals: list[SignalConfig] = field(default_factory=list)
     methods: list[MethodConfig] = field(default_factory=list)
     properties: list[PropertyConfig] = field(default_factory=list)
@@ -39,6 +40,11 @@ class InterfaceConfig:
     def render_mqtt_command_topic(self, template_engine: TemplateEngine, context: dict[str, Any]) -> Any:
         if self.mqtt_command_topic:
             return template_engine.render_template(self.mqtt_command_topic, str, context)
+        return None
+
+    def render_mqtt_response_topic(self, template_engine: TemplateEngine, context: dict[str, Any]) -> str | None:
+        if self.mqtt_response_topic:
+            return template_engine.render_template(self.mqtt_response_topic, str, context)
         return None
 
 @dataclass

--- a/src/dbus2mqtt/dbus/dbus_client.py
+++ b/src/dbus2mqtt/dbus/dbus_client.py
@@ -746,11 +746,15 @@ class DbusClient:
                 await self._handle_interfaces_removed(bus_name, path)
 
     async def _on_mqtt_msg(self, msg: MqttMessage):
-        """Executes dbus method calls or property updates on objects when messages have
+        """Enhanced version that publishes method responses to MQTT.
+        
+        Executes dbus method calls or property updates on objects when messages have:
         1. a matching subscription configured
         2. a matching method
-        3. a matching bus_name (if provided)
+        3. a matching bus_name (if provided) 
         4. a matching path (if provided)
+        
+        For method calls, responses are published to <original_topic>/response
         """
 
         found_matching_topic = False
@@ -781,6 +785,10 @@ class DbusClient:
                 logger.info(f"on_mqtt_msg: Unsupported payload, missing 'method' or 'property/value', got method={payload_method}, property={payload_property}, value={payload_value} from {msg.payload}")
             return
 
+        # Prepare response topic for method calls
+        response_topic = f"{msg.topic}/response" if payload_method else None
+        method_responses = []
+
         for [bus_name, bus_name_subscription] in self.subscriptions.items():
             if fnmatch.fnmatchcase(bus_name, payload_bus_name):
                 for [path, proxy_object] in bus_name_subscription.path_objects.items():
@@ -795,11 +803,39 @@ class DbusClient:
                                         interface = proxy_object.get_interface(name=interface_config.interface)
                                         matched_method = True
 
+                                        # Prepare method response data
+                                        method_response = {
+                                            "method": method.method,
+                                            "bus_name": bus_name,
+                                            "path": path,
+                                            "interface": interface_config.interface,
+                                            "args": payload_method_args,
+                                            "timestamp": datetime.now().isoformat()
+                                        }
+
                                         try:
                                             logger.info(f"on_mqtt_msg: method={method.method}, args={payload_method_args}, bus_name={bus_name}, path={path}, interface={interface_config.interface}")
-                                            await self.call_dbus_interface_method(interface, method.method, payload_method_args)
+                                            
+                                            # Execute the D-Bus method call
+                                            result = await self.call_dbus_interface_method(interface, method.method, payload_method_args)
+                                            
+                                            # Add success response data
+                                            method_response.update({
+                                                "success": True,
+                                                "result": result
+                                            })
+                                            
                                         except Exception as e:
                                             logger.warning(f"on_mqtt_msg: method={method.method}, args={payload_method_args}, bus_name={bus_name} failed, exception={e}")
+                                            
+                                            # Add error response data
+                                            method_response.update({
+                                                "success": False,
+                                                "error": str(e),
+                                                "error_type": type(e).__name__
+                                            })
+
+                                        method_responses.append(method_response)
 
                                 for property in interface_config.properties:
                                     # filter configured property, configured topic, ...
@@ -813,8 +849,40 @@ class DbusClient:
                                         except Exception as e:
                                             logger.warning(f"on_mqtt_msg: property={property.property}, value={payload_value}, bus_name={bus_name} failed, exception={e}")
 
+        # Publish method responses to MQTT
+        if response_topic and method_responses:
+            await self._publish_method_responses(response_topic, method_responses)
+
         if not matched_method and not matched_property:
             if payload_method:
                 logger.info(f"No configured or active dbus subscriptions for topic={msg.topic}, method={payload_method}, bus_name={payload_bus_name}, path={payload_path or '*'}, active bus_names={list(self.subscriptions.keys())}")
             if payload_property:
                 logger.info(f"No configured or active dbus subscriptions for topic={msg.topic}, property={payload_property}, bus_name={payload_bus_name}, path={payload_path or '*'}, active bus_names={list(self.subscriptions.keys())}")
+
+    async def _publish_method_responses(self, response_topic: str, responses: list[dict[str, Any]]):
+        """
+        Publishes method call responses to MQTT.
+        
+        Args:
+            response_topic: MQTT topic to publish responses to
+            responses: List of response dictionaries
+        """
+        try:
+            # If single response, publish it directly
+            # If multiple responses, publish as array
+            payload = responses[0] if len(responses) == 1 else responses
+            
+            from dbus2mqtt.event_broker import MqttMessage
+            
+            mqtt_message = MqttMessage(
+                topic=response_topic,
+                payload=payload,
+                payload_serialization_type="json"
+            )
+            
+            await self.event_broker.publish_to_mqtt(mqtt_message)
+            
+            logger.debug(f"Published method response(s) to {response_topic}: {len(responses)} response(s)")
+            
+        except Exception as e:            
+            logger.error(f"Failed to publish method responses to {response_topic}: {e}")

--- a/src/dbus2mqtt/dbus/dbus_util.py
+++ b/src/dbus2mqtt/dbus/dbus_util.py
@@ -1,8 +1,13 @@
 import base64
 import re
+import logging
 
+from typing import Any, Dict, List, Union
+
+from dbus_fast import Variant
 import dbus_fast.signature as dbus_signature
 
+logger = logging.getLogger(__name__)
 
 def unwrap_dbus_object(obj):
     if isinstance(obj, dict):
@@ -22,3 +27,200 @@ def unwrap_dbus_objects(args):
 
 def camel_to_snake(name):
     return re.sub(r'([a-z])([A-Z])', r'\1_\2', name).lower()
+
+def convert_mqtt_args_to_dbus(args: List[Any]) -> List[Any]:
+    """
+    Convert MQTT/JSON arguments to D-Bus compatible arguments.
+    
+    Args:
+        args: List of arguments from MQTT (typically JSON deserialized objects)
+        
+    Returns:
+        List of D-Bus compatible arguments
+        
+    Example:
+        # For ConnMan SetProperty with nested dict:
+        mqtt_args = [{"Ethernet": {"Method": "auto", "Interface": "end1", "Address": "3E:67:8C:CE:CF:86", "MTU": 2000}}]
+        dbus_args = convert_mqtt_args_to_dbus(mqtt_args)
+    """
+    converted_args = []
+    
+    for arg in args:
+        converted_arg = _convert_value_to_dbus(arg)
+        # If the converted argument is a dict, it needs to be wrapped in a Variant for D-Bus
+        if isinstance(converted_arg, dict):
+            signature = _get_dbus_signature(converted_arg)
+            converted_arg = Variant(signature, converted_arg)
+        converted_args.append(converted_arg)
+    
+    return converted_args
+
+def _convert_value_to_dbus(value: Any) -> Any:
+    """
+    Recursively convert a single value to D-Bus compatible type.
+    
+    Args:
+        value: The value to convert (can be dict, list, primitive, etc.)
+        
+    Returns:
+        D-Bus compatible value
+    """
+    if value is None:
+        return value
+    
+    elif isinstance(value, dict):
+        # Convert dict to D-Bus dictionary (a{sv} - dictionary of string to variant)
+        dbus_dict = {}
+        for k, v in value.items():
+            # Keys are typically strings in D-Bus dictionaries
+            key = str(k)
+            # Recursively convert the value first, then wrap in Variant
+            converted_value = _convert_value_to_dbus(v)
+            # Determine the appropriate D-Bus signature for the converted value
+            signature = _get_dbus_signature(converted_value)
+            dbus_dict[key] = Variant(signature, converted_value)
+        return dbus_dict
+    
+    elif isinstance(value, list):
+        # Convert list to D-Bus array
+        converted_list = []
+        for item in value:
+            converted_list.append(_convert_value_to_dbus(item))
+        return converted_list
+    
+    elif isinstance(value, bool):
+        # Boolean values are fine as-is for D-Bus
+        return value
+    
+    elif isinstance(value, int):
+        # Integer values are fine as-is for D-Bus
+        return value
+    
+    elif isinstance(value, float):
+        # Float values are fine as-is for D-Bus
+        return value
+    
+    elif isinstance(value, str):
+        # String values are fine as-is for D-Bus
+        return value
+    
+    else:
+        # For any other type, try to convert to string as fallback
+        logger.warning(f"Unknown type {type(value)} for D-Bus conversion, converting to string: {value}")
+        return str(value)
+
+def _get_dbus_signature(value: Any) -> str:
+    """
+    Get the appropriate D-Bus signature for a value.
+    
+    Args:
+        value: The value to get signature for
+        
+    Returns:
+        D-Bus type signature string
+    """
+    if isinstance(value, bool):
+        return 'b'  # boolean
+    elif isinstance(value, int):
+        UINT16_MIN = 0
+        UINT16_MAX = 0xFFFF
+        INT16_MIN = -0x7FFF - 1
+        INT16_MAX = 0x7FFF
+        UINT32_MIN = 0
+        UINT32_MAX = 0xFFFFFFFF
+        INT32_MIN = -0x7FFFFFFF - 1
+        INT32_MAX = 0x7FFFFFFF
+        UINT64_MIN = 0
+        UINT64_MAX = 18446744073709551615
+
+        if UINT16_MIN <= value <= UINT16_MAX:
+            return 'q'  # 16-bit unsigned int
+        elif INT16_MIN <= value <= INT16_MAX:
+            return 'n'  # 16-bit signed int
+        elif UINT32_MIN <= value <= UINT32_MAX:
+            return 'u'  # 32-bit unsigned int
+        elif INT32_MIN <= value <= INT32_MAX:
+            return 'i'  # 32-bit signed integer
+        elif UINT64_MIN <= value <= UINT64_MAX:
+            return 't'  # 64-bit unsigned integer
+        else:
+            return 'x'  # 64-bit signed integer
+    elif isinstance(value, float):
+        return 'd'  # double
+    elif isinstance(value, str):
+        return 's'  # string
+    elif isinstance(value, list):
+        if not value:
+            return 'as'  # assume array of strings for empty arrays
+        # Get signature of first element and assume homogeneous array
+        element_sig = _get_dbus_signature(value[0])
+        return f'a{element_sig}'  # array of elements
+    elif isinstance(value, dict):
+        return 'a{sv}'  # dictionary of string to variant
+    else:
+        return 's'  # fallback to string
+
+# Helper function specifically for ConnMan-style property setting
+def convert_connman_property_args(property_value: Any) -> Any:
+    """
+    Helper function specifically for ConnMan SetProperty calls.
+    
+    ConnMan SetProperty expects: SetProperty(variant property_value)
+    
+    Args:
+        property_value: Value to set (will be converted and wrapped in Variant)
+        
+    Returns:
+        List with Variant(converted_value)
+    """
+    converted_value = _convert_value_to_dbus(property_value)
+    signature = _get_dbus_signature(converted_value)
+    return Variant(signature, converted_value)
+
+# Alternative conversion that wraps all complex types in Variants
+def convert_mqtt_args_to_dbus_explicit_variants(args: List[Any]) -> List[Any]:
+    """
+    Convert MQTT/JSON arguments to D-Bus with explicit Variant wrapping for all complex types.
+    This version is more aggressive about wrapping things in Variants.
+    
+    Args:
+        args: List of arguments from MQTT
+        
+    Returns:
+        List of D-Bus compatible arguments with explicit Variants
+    """
+    converted_args = []
+    
+    for arg in args:
+        converted_arg = _convert_and_wrap_in_variant(arg)
+        converted_args.append(converted_arg)
+    
+    return converted_args
+
+def _convert_and_wrap_in_variant(value: Any) -> Any:
+    """
+    Convert a value and wrap complex types in Variants.
+    """
+    if value is None:
+        return value
+    elif isinstance(value, (bool, int, float, str)):
+        # Primitive types can be used as-is or wrapped in Variant if needed
+        return value
+    elif isinstance(value, dict):
+        # Convert dict and wrap in Variant
+        converted_dict = {}
+        for k, v in value.items():
+            key = str(k)
+            converted_value = _convert_value_to_dbus(v)
+            signature = _get_dbus_signature(converted_value)
+            converted_dict[key] = Variant(signature, converted_value)
+        return Variant('a{sv}', converted_dict)
+    elif isinstance(value, list):
+        # Convert list and potentially wrap in Variant
+        converted_list = []
+        for item in value:
+            converted_list.append(_convert_and_wrap_in_variant(item))
+        return converted_list
+    else:
+        # Fallback
+        return str(value)


### PR DESCRIPTION
This PR adds a way to configure mqtt_response_topic associated with mqtt_command_topic, for example:

```yaml
- bus_name: net.connman
      path: /net/connman/service/*
      interfaces:  
        - interface: net.connman.Service  
          mqtt_command_topic: internal/hardware/net/service/command
          mqtt_response_topic: internal/hardware/net/service/response/{{ method }} 
          methods:  
            - method: GetProperties
            - method: SetProperty
            - method: Connect
            - method: Disconnect
            - method: Remove
```

It also adds a way to push property changes (SetProperty) as dbus_fast was rejecting for variant conversion error. This PR aims to fix that