### PR TITLE
Added dbus2mqtt.version jinja global

### DIFF
--- a/docs/examples/dbus2mqtt_internal_state.yaml
+++ b/docs/examples/dbus2mqtt_internal_state.yaml
@@ -39,6 +39,7 @@ flows:
         payload_type: json
         payload_template:
           now: "{{ now().isoformat() }}"
+          dbus2mqtt: " {{ dbus2mqtt }}"
           dbus_list_res: "{{ dbus_list('*') }}"
       - type: log
         level: INFO

--- a/docs/templating/index.md
+++ b/docs/templating/index.md
@@ -2,13 +2,19 @@
 
 **dbus2mqtt** leverages Jinja to allow formatting MQTT messages, D-Bus responses or advanced configuration use-cases. If you are not familiar with Jinja based expressions, have a look at Jinjas own [Template Designer Documentation](https://jinja.palletsprojects.com/en/stable/templates/).
 
-Besides the filters and functions Jinja provides out of the box, the following extensions are available:
-
-* [jinja2-ansible-filters](https://pypi.org/project/jinja2-ansible-filters/)
-
-More documentation to be added, for now see the [Mediaplayer integration with Home Assistant](../examples/home_assistant_media_player.md) example for inspiration.
-
 Templating is used in these areas of dbus2mqtt:
 
 * [subscriptions](../subscriptions.md)
 * [flow actions](../flows/flow_actions.md)
+
+Besides the filters and functions Jinja provides out of the box, additional extensions are available.
+
+All filters from [jinja2-ansible-filters](https://pypi.org/project/jinja2-ansible-filters/) are included as well as the following global functions, variables and filters:
+
+| Name                | Type      | Description                                                                 |
+|---------------------|-----------|-----------------------------------------------------------------------------|
+| `now`               | function  | Returns the current date and time as a `datetime` object.                   |
+| `urldecode`         | function  | Decodes a URL-encoded string.                                               |
+| `dbus2mqtt.version` | string    | The current version of the `dbus2mqtt` package.                             |
+
+More documentation to be added, for now see the [Mediaplayer integration with Home Assistant](../examples/home_assistant_media_player.md) example for inspiration.

--- a/src/dbus2mqtt/template/templating.py
+++ b/src/dbus2mqtt/template/templating.py
@@ -1,6 +1,7 @@
 import urllib.parse
 
 from datetime import datetime
+from importlib.metadata import version
 from typing import Any, TypeVar
 
 from jinja2 import (
@@ -24,6 +25,9 @@ class TemplateEngine:
         engine_globals = {}
         engine_globals['now'] = datetime.now
         engine_globals['urldecode'] = urldecode
+        engine_globals['dbus2mqtt'] = {
+            'version': version('dbus2mqtt')
+        }
 
         engine_filters = {}
         engine_filters['urldecode'] = urldecode


### PR DESCRIPTION
With `dbus2mqtt.version` added, this is the new list of jinja globals and filters

| Name                | Type      | Description                                                                 |
|---------------------|-----------|-----------------------------------------------------------------------------|
| `now`               | function  | Returns the current date and time as a `datetime` object.                   |
| `urldecode`         | function  | Decodes a URL-encoded string.                                               |
| `dbus2mqtt.version` | string    | The current version of the `dbus2mqtt` package.                             |
