### PR TITLE
Conditional flow execution

### DIFF
--- a/docs/flows/index.md
+++ b/docs/flows/index.md
@@ -28,7 +28,7 @@ flows:
         msg: hello from example flow
 ```
 
-Subscription based flows are started when dbus2mqtt is subscribed to one or more dbus objects. No matter the amount of dbus objects subscribed, there is at most one flow instance running.
+Subscription based flows are started when dbus2mqtt is subscribed to one or more dbus objects. No matter the number of dbus objects subscribed, there is at most one flow instance running.
 
 ```yaml title="Subscription based flows"
 dbus:
@@ -46,5 +46,26 @@ dbus:
 ```
 
 Some action parameters allow the use of templating. When supported, it is documented for each individual trigger and action. See [templating](../templating/index.md) for further templating details.
+
+## Contional flows
+
+Flow actions can be conditionally executed. The `conditions` parameter accepts either a templated string or list of strings.
+When using a list of templated strings, all expressions must evaluate to `True` for the actions to be executed.
+
+```yaml title="Subscription based flows"
+dbus:
+  subscriptions:
+    - bus_name: org.mpris.MediaPlayer2.*
+      path: /org/mpris/MediaPlayer2
+      flows:
+        - name: Example conditional flow
+          triggers:
+            - type: object_added
+          conditions:
+            - "{{ 'vlc' in bus_name }}"
+          actions:
+            - type: log
+              msg: VLC player registered
+```
 
 Next: [flow actions](flow_actions.md) & [flow triggers](flow_triggers.md)

--- a/src/dbus2mqtt/config/__init__.py
+++ b/src/dbus2mqtt/config/__init__.py
@@ -139,6 +139,7 @@ FlowActionConfig = (
 class FlowConfig:
     triggers: list[FlowTriggerConfig]
     actions: list[FlowActionConfig]
+    conditions: str | list[str] = field(default_factory=list)
     name: str | None = None
     id: str = field(default_factory=lambda: uuid.uuid4().hex)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -49,9 +49,9 @@ def mocked_app_context():
 
     return app_context
 
-def mocked_flow_processor(app_context: AppContext, trigger_config: FlowTriggerConfig, actions: list[FlowActionConfig]):
+def mocked_flow_processor(app_context: AppContext, trigger_config: FlowTriggerConfig, actions: list[FlowActionConfig], conditions: list[str] = []):
 
-    flow_config = FlowConfig(triggers=[trigger_config], actions=actions)
+    flow_config = FlowConfig(triggers=[trigger_config], actions=actions, conditions=conditions)
 
     app_context.config.dbus.subscriptions[0].flows = [flow_config]
 

--- a/tests/flow/test_flow_processor.py
+++ b/tests/flow/test_flow_processor.py
@@ -148,22 +148,50 @@ async def test_dbus_signal_trigger():
         "subscription_interfaces": ["test-interface-name"]
     }
 
-# @pytest.mark.asyncio
-# async def test_mqtt_trigger():
+@pytest.mark.asyncio
+async def test_flow_conditions_should_execute():
 
-#     app_context = mocked_app_context()
+    app_context = mocked_app_context()
 
-#     trigger_config = FlowTriggerMqttConfig()
-#     processor, flow_config = mocked_flow_processor(app_context, trigger_config, actions=[
-#         FlowActionContextSetConfig(
-#             global_context={
-#                 "res": "mqtt"
-#             }
-#         )
-#     ])
+    trigger_config = FlowTriggerObjectAddedConfig()
+    processor, flow_config = mocked_flow_processor(
+        app_context, trigger_config,
+        actions=[
+            FlowActionContextSetConfig(
+                global_context={
+                    "res": "triggered_by_context_changed"
+                }
+            )
+        ],
+        conditions=["{{ True }}"]
+    )
 
-#     await processor._process_flow_trigger(
-#         FlowTriggerMessage(flow_config, trigger_config, datetime.now())
-#     )
+    await processor._process_flow_trigger(
+        FlowTriggerMessage(flow_config, trigger_config, datetime.now())
+    )
 
-#     assert processor._global_context["res"] == "mqtt"
+    assert "res" in processor._global_context
+
+@pytest.mark.asyncio
+async def test_flow_conditions_should_not_execute():
+
+    app_context = mocked_app_context()
+
+    trigger_config = FlowTriggerObjectAddedConfig()
+    processor, flow_config = mocked_flow_processor(
+        app_context, trigger_config,
+        actions=[
+            FlowActionContextSetConfig(
+                global_context={
+                    "res": "triggered_by_context_changed"
+                }
+            )
+        ],
+        conditions=["{{ False }}"]
+    )
+
+    await processor._process_flow_trigger(
+        FlowTriggerMessage(flow_config, trigger_config, datetime.now())
+    )
+
+    assert "res" not in processor._global_context


### PR DESCRIPTION
Flow actions can be conditionally executed. The `conditions` parameter accepts either a templated string or list of strings.
When using a list of templated strings, all expressions must evaluate to `True` for the actions to be executed.

```yaml title="Subscription based flows"
dbus:
  subscriptions:
    - bus_name: org.mpris.MediaPlayer2.*
      path: /org/mpris/MediaPlayer2
      flows:
        - name: Example conditional flow
          triggers:
            - type: object_added
          conditions:
            - "{{ 'vlc' in bus_name }}"
          actions:
            - type: log
              msg: VLC player registered
```