### PR TITLE
Support for subscribing to MQTT messages with text payloads

### DIFF
--- a/docs/flows/flow_triggers.md
+++ b/docs/flows/flow_triggers.md
@@ -88,10 +88,11 @@ Listens for MQTT messages on the configured topic. The message payload is expect
 
 Trigger configuration:
 
-| key | description  |
-|------|-------------|
-| topic     | topic to subscribe to, e.g. 'dbus2mqtt/org.mpris.MediaPlayer2/flow-trigger' |
-| filter    | A templated string that must evaluate to a boolean result. When False, the flow is not triggered |
+| key          | description  |
+|--------------|--------------|
+| topic        | topic to subscribe to, e.g. 'dbus2mqtt/org.mpris.MediaPlayer2/flow-trigger' |
+| content_type | One of `json` or `text`, defaults to `json` |
+| filter       | A templated string that must evaluate to a boolean result. When False, the flow is not triggered |
 
 When triggered, the following context parameters are available
 
@@ -99,7 +100,7 @@ When triggered, the following context parameters are available
 |--------------|--------|------------------|
 | trigger_type | string | 'mqtt_message'   |
 | topic        | string | mqtt topic |
-| payload      | any    | json deserialized MQTT message payload  |
+| payload      | any    | text or json deserialized MQTT message payload |
 
 Example flow
 

--- a/src/dbus2mqtt/config/__init__.py
+++ b/src/dbus2mqtt/config/__init__.py
@@ -98,6 +98,7 @@ class FlowTriggerDbusObjectRemovedConfig:
 class FlowTriggerMqttMessageConfig:
     topic: str
     type: Literal["mqtt_message"] = "mqtt_message"
+    content_type: Literal["json", "text"] = "json"
     filter: str | None = None
 
     def matches_filter(self, template_engine: TemplateEngine, trigger_context: dict[str, Any]) -> bool:

--- a/tests/flow/triggers/test_mqtt_client_triggers.py
+++ b/tests/flow/triggers/test_mqtt_client_triggers.py
@@ -22,10 +22,7 @@ async def test_mqtt_message_trigger():
     processor =_mocked_flow_processor(app_context, trigger_config)
     mqtt_client = mocked_mqtt_client(app_context)
 
-    mqtt_client._trigger_flows(topic=test_topic, trigger_context={
-        "topic": test_topic,
-        "payload": test_payload
-    })
+    mqtt_client._trigger_flows(topic=test_topic, payload="", json_payload=test_payload)
 
     trigger = app_context.event_broker.flow_trigger_queue.sync_q.get_nowait()
 
@@ -55,10 +52,7 @@ async def test_mqtt_message_trigger_filter_true():
     _ = _mocked_flow_processor(app_context, trigger_config)
     mqtt_client = mocked_mqtt_client(app_context)
 
-    mqtt_client._trigger_flows(topic=test_topic, trigger_context={
-        "topic": test_topic,
-        "payload": test_payload
-    })
+    mqtt_client._trigger_flows(topic=test_topic, payload="", json_payload=test_payload)
 
     assert app_context.event_broker.flow_trigger_queue.sync_q.qsize() == 1
 
@@ -78,10 +72,7 @@ async def test_mqtt_message_trigger_filter_false():
     _ =_mocked_flow_processor(app_context, trigger_config)
     mqtt_client = mocked_mqtt_client(app_context)
 
-    mqtt_client._trigger_flows(topic=test_topic, trigger_context={
-        "topic": test_topic,
-        "payload": test_payload
-    })
+    mqtt_client._trigger_flows(topic=test_topic, payload="", json_payload=test_payload)
 
     assert app_context.event_broker.flow_trigger_queue.sync_q.qsize() == 0
 


### PR DESCRIPTION
Added `content_type` parameter to MQTT trigger config. Defaults to `json` but can be set to `text`.

Example flow configuration

```yaml
        - name: Home Assistant Discovery
          triggers:
            - type: mqtt_message
              topic: homeassistant/status
              content_type: text
              filter: "{{ payload == 'online' }}"
```

Fixes #270 