### PR TITLE
Add MQTTS (TLS) support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,9 @@ MQTT__HOST=localhost
 MQTT__PORT=1883
 MQTT__USERNAME=
 MQTT__PASSWORD=
+# MQTTS (TLS) options — set MQTT__TLS_ENABLED=true and MQTT__PORT=8883 to enable
+MQTT__TLS_ENABLED=false
+# MQTT__TLS_CA_CERT=/path/to/ca.crt
+# MQTT__TLS_CERTFILE=/path/to/client.crt
+# MQTT__TLS_KEYFILE=/path/to/client.key
+# MQTT__TLS_INSECURE=false

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -62,6 +62,11 @@ MQTT connection details can be configured via a mix of environment variables and
 | `mqtt.username`            | `MQTT__USERNAME` | Username                 |
 | `mqtt.password`            | <nobr>`MQTT__PASSWORD`</nobr> | Password    |
 | `mqtt.subscription_topics` |                  | List of topics that dbus2mqtt will subscribe to, defaults to `["dbus2mqtt/#"]` |
+| `mqtt.tls_enabled`         |                  | Enable TLS/SSL (MQTTS), defaults to `false` |
+| `mqtt.tls_ca_certs`        |                  | Path to CA certificate file for server verification. Uses system CAs if not set. |
+| `mqtt.tls_certfile`        |                  | Path to client certificate file for mutual TLS authentication. |
+| `mqtt.tls_keyfile`         |                  | Path to client private key file for mutual TLS authentication. |
+| `mqtt.tls_insecure`        |                  | Disable server certificate hostname verification. Use only for testing with self-signed certs, defaults to `false`. |
 
 ### dbus2mqtt **dbus** config
 

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -506,6 +506,28 @@
             "type": "string"
           },
           "description": "List of MQTT topics to subscribe to. Wildcard characters '#' and '+' are supported."
+        },
+        "tls_enabled": {
+          "type": "boolean",
+          "description": "Enable TLS/SSL for the MQTT connection (MQTTS). Defaults to false.",
+          "default": false
+        },
+        "tls_ca_cert": {
+          "type": ["string", "null"],
+          "description": "Path to CA certificate file for server verification. Uses system CAs if not set."
+        },
+        "tls_certfile": {
+          "type": ["string", "null"],
+          "description": "Path to client certificate file for mutual TLS authentication."
+        },
+        "tls_keyfile": {
+          "type": ["string", "null"],
+          "description": "Path to client private key file for mutual TLS authentication."
+        },
+        "tls_insecure": {
+          "type": "boolean",
+          "description": "Disable server certificate hostname verification. Use only for testing with self-signed certs.",
+          "default": false
         }
       },
       "additionalProperties": false,

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -509,25 +509,23 @@
         },
         "tls_enabled": {
           "type": "boolean",
-          "description": "Enable TLS/SSL for the MQTT connection (MQTTS). Defaults to false.",
-          "default": false
+          "description": "Enable TLS/SSL for the MQTT connection (MQTTS). Defaults to False."
         },
         "tls_ca_cert": {
-          "type": ["string", "null"],
+          "type": "string",
           "description": "Path to CA certificate file for server verification. Uses system CAs if not set."
         },
         "tls_certfile": {
-          "type": ["string", "null"],
+          "type": "string",
           "description": "Path to client certificate file for mutual TLS authentication."
         },
         "tls_keyfile": {
-          "type": ["string", "null"],
+          "type": "string",
           "description": "Path to client private key file for mutual TLS authentication."
         },
         "tls_insecure": {
           "type": "boolean",
-          "description": "Disable server certificate hostname verification. Use only for testing with self-signed certs.",
-          "default": false
+          "description": "Disable server certificate hostname verification. Use only for testing with self-signed certs."
         }
       },
       "additionalProperties": false,

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -29,7 +29,10 @@
           "type": "string"
         },
         "filter": {
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false,
@@ -69,11 +72,17 @@
           "description": "The D-Bus interface that defines the set of methods, signals, and properties available."
         },
         "mqtt_command_topic": {
-          "type": "string",
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "MQTT topic where dbus2mqtt listens for JSON commands. For example 'dbus2mqtt/mpris/command'. Value can be a string or templated string."
         },
         "mqtt_response_topic": {
-          "type": "string",
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "MQTT topic where dbus2mqtt published responses on. For example 'dbus2mqtt/mpris/response'. Value can be a string or templated string."
         },
         "signals": {
@@ -181,15 +190,24 @@
           "default": "dbus_signal"
         },
         "interface": {
-          "type": "string",
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Interface to filter on, e.g. 'org.freedesktop.DBus.Properties'."
         },
         "bus_name": {
-          "type": "string",
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "undocumented, not used."
         },
         "path": {
-          "type": "string",
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "undocumented, not used."
         }
       },
@@ -219,7 +237,10 @@
           "default": "json"
         },
         "filter": {
-          "type": "string",
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Optional template expression, trigger only when it evaluates truthy."
         }
       },
@@ -240,10 +261,16 @@
           "type": "string"
         },
         "cron": {
-          "type": "object"
+          "type": [
+            "object",
+            "null"
+          ]
         },
         "interval": {
-          "type": "object"
+          "type": [
+            "object",
+            "null"
+          ]
         }
       },
       "additionalProperties": false
@@ -296,11 +323,17 @@
           "default": "context_set"
         },
         "context": {
-          "type": "object",
+          "type": [
+            "object",
+            "null"
+          ],
           "description": "Per flow execution context."
         },
         "global_context": {
-          "type": "object",
+          "type": [
+            "object",
+            "null"
+          ],
           "description": "Global context, shared between multiple flow executions, over all subscriptions."
         }
       },
@@ -403,7 +436,10 @@
           "description": "Optional condition or list of conditions that must be met before a flow is executed."
         },
         "name": {
-          "type": "string",
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Optional human-readable name for the flow."
         },
         "id": {
@@ -511,16 +547,25 @@
           "type": "boolean",
           "description": "Enable TLS/SSL for the MQTT connection (MQTTS). Defaults to False."
         },
-        "tls_ca_cert": {
-          "type": "string",
+        "tls_ca_certs": {
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Path to CA certificate file for server verification. Uses system CAs if not set."
         },
         "tls_certfile": {
-          "type": "string",
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Path to client certificate file for mutual TLS authentication."
         },
         "tls_keyfile": {
-          "type": "string",
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Path to client private key file for mutual TLS authentication."
         },
         "tls_insecure": {

--- a/src/dbus2mqtt/config/__init__.py
+++ b/src/dbus2mqtt/config/__init__.py
@@ -338,7 +338,7 @@ class MqttConfig:
         port: MQTT broker TCP port.
         subscription_topics: List of MQTT topics to subscribe to. Wildcard characters '#' and '+' are supported.
         tls_enabled: Enable TLS/SSL for the MQTT connection (MQTTS). Defaults to False.
-        tls_ca_cert: Path to CA certificate file for server verification. Uses system CAs if not set.
+        tls_ca_certs: Path to CA certificate file for server verification. Uses system CAs if not set.
         tls_certfile: Path to client certificate file for mutual TLS authentication.
         tls_keyfile: Path to client private key file for mutual TLS authentication.
         tls_insecure: Disable server certificate hostname verification. Use only for testing with self-signed certs.
@@ -350,7 +350,7 @@ class MqttConfig:
     port: int = 1883
     subscription_topics: list[str] = field(default_factory=lambda: ["dbus2mqtt/#"])
     tls_enabled: bool = False
-    tls_ca_cert: str | None = None
+    tls_ca_certs: str | None = None
     tls_certfile: str | None = None
     tls_keyfile: str | None = None
     tls_insecure: bool = False

--- a/src/dbus2mqtt/config/__init__.py
+++ b/src/dbus2mqtt/config/__init__.py
@@ -337,6 +337,11 @@ class MqttConfig:
         password: Password for broker authentication.
         port: MQTT broker TCP port.
         subscription_topics: List of MQTT topics to subscribe to. Wildcard characters '#' and '+' are supported.
+        tls_enabled: Enable TLS/SSL for the MQTT connection (MQTTS). Defaults to False.
+        tls_ca_cert: Path to CA certificate file for server verification. Uses system CAs if not set.
+        tls_certfile: Path to client certificate file for mutual TLS authentication.
+        tls_keyfile: Path to client private key file for mutual TLS authentication.
+        tls_insecure: Disable server certificate hostname verification. Use only for testing with self-signed certs.
     """
 
     host: str
@@ -344,6 +349,11 @@ class MqttConfig:
     password: SecretStr
     port: int = 1883
     subscription_topics: list[str] = field(default_factory=lambda: ["dbus2mqtt/#"])
+    tls_enabled: bool = False
+    tls_ca_cert: str | None = None
+    tls_certfile: str | None = None
+    tls_keyfile: str | None = None
+    tls_insecure: bool = False
 
 
 @dataclass

--- a/src/dbus2mqtt/mqtt/mqtt_client.py
+++ b/src/dbus2mqtt/mqtt/mqtt_client.py
@@ -51,7 +51,7 @@ class MqttClient:
 
         if self.config.tls_enabled:
             self.client.tls_set(
-                ca_certs=self.config.tls_ca_cert,
+                ca_certs=self.config.tls_ca_certs,
                 certfile=self.config.tls_certfile,
                 keyfile=self.config.tls_keyfile,
             )

--- a/src/dbus2mqtt/mqtt/mqtt_client.py
+++ b/src/dbus2mqtt/mqtt/mqtt_client.py
@@ -49,6 +49,15 @@ class MqttClient:
             username=self.config.username, password=self.config.password.get_secret_value()
         )
 
+        if self.config.tls_enabled:
+            self.client.tls_set(
+                ca_certs=self.config.tls_ca_cert,
+                certfile=self.config.tls_certfile,
+                keyfile=self.config.tls_keyfile,
+            )
+            if self.config.tls_insecure:
+                self.client.tls_insecure_set(True)
+
         self.client.on_connect = self._on_connect
         self.client.on_message = self._on_message_safe
 

--- a/tests/mqtt/test_mqtt_client.py
+++ b/tests/mqtt/test_mqtt_client.py
@@ -1,0 +1,73 @@
+from unittest.mock import MagicMock, patch
+
+from jsonargparse.typing import SecretStr
+
+from dbus2mqtt import AppContext, config
+from dbus2mqtt.event_broker import EventBroker
+from dbus2mqtt.mqtt.mqtt_client import MqttClient
+from dbus2mqtt.template.templating import TemplateEngine
+
+
+def _make_app_context(mqtt_config: config.MqttConfig) -> AppContext:
+    cfg = config.Config(
+        dbus=config.DbusConfig(subscriptions=[]),
+        mqtt=mqtt_config,
+        flows=[],
+    )
+    return AppContext(cfg, EventBroker(), TemplateEngine())
+
+
+def _base_mqtt_config(**kwargs) -> config.MqttConfig:
+    return config.MqttConfig(host="localhost", username="test", password=SecretStr("test"), **kwargs)
+
+
+def test_tls_enabled_calls_tls_set():
+    app_context = _make_app_context(_base_mqtt_config(tls_enabled=True))
+    with patch("dbus2mqtt.mqtt.mqtt_client.mqtt.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        MqttClient(app_context, None)
+        mock_client.tls_set.assert_called_once_with(
+            ca_certs=None,
+            certfile=None,
+            keyfile=None,
+        )
+        mock_client.tls_insecure_set.assert_not_called()
+
+
+def test_tls_insecure_calls_tls_insecure_set():
+    app_context = _make_app_context(_base_mqtt_config(tls_enabled=True, tls_insecure=True))
+    with patch("dbus2mqtt.mqtt.mqtt_client.mqtt.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        MqttClient(app_context, None)
+        mock_client.tls_insecure_set.assert_called_once_with(True)
+
+
+def test_tls_with_certs():
+    app_context = _make_app_context(
+        _base_mqtt_config(
+            tls_enabled=True,
+            tls_ca_certs="/path/to/ca.crt",
+            tls_certfile="/path/to/client.crt",
+            tls_keyfile="/path/to/client.key",
+        )
+    )
+    with patch("dbus2mqtt.mqtt.mqtt_client.mqtt.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        MqttClient(app_context, None)
+        mock_client.tls_set.assert_called_once_with(
+            ca_certs="/path/to/ca.crt",
+            certfile="/path/to/client.crt",
+            keyfile="/path/to/client.key",
+        )
+
+
+def test_tls_disabled_does_not_call_tls_set():
+    app_context = _make_app_context(_base_mqtt_config(tls_enabled=False))
+    with patch("dbus2mqtt.mqtt.mqtt_client.mqtt.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        MqttClient(app_context, None)
+        mock_client.tls_set.assert_not_called()

--- a/tests/mqtt/test_mqtt_client.py
+++ b/tests/mqtt/test_mqtt_client.py
@@ -18,7 +18,9 @@ def _make_app_context(mqtt_config: config.MqttConfig) -> AppContext:
 
 
 def _base_mqtt_config(**kwargs) -> config.MqttConfig:
-    return config.MqttConfig(host="localhost", username="test", password=SecretStr("test"), **kwargs)
+    return config.MqttConfig(
+        host="localhost", username="test", password=SecretStr("test"), **kwargs
+    )
 
 
 def test_tls_enabled_calls_tls_set():

--- a/tools/generate_schema.py
+++ b/tools/generate_schema.py
@@ -112,15 +112,27 @@ class SchemaGenerator:
             return {"enum": vals}
 
         if is_union(tp):
+            nullable = is_optional(tp)
             union_types = [a for a in get_args(tp) if a is not types.NoneType]
             union_schema_types = [self.python_type_to_schema_optional(a) for a in union_types]
             if None in union_schema_types:
                 union_schema_types.remove(None)
 
             if len(union_schema_types) == 1:
-                return union_schema_types[0]
+                result = union_schema_types[0]
+                if (
+                    nullable
+                    and result is not None
+                    and "type" in result
+                    and isinstance(result["type"], str)
+                ):
+                    return {**result, "type": [result["type"], "null"]}
+                return result
             elif len(union_schema_types) > 1:
-                return {"anyOf": union_schema_types}
+                schema = {"anyOf": union_schema_types}
+                if nullable:
+                    schema["anyOf"].append({"type": "null"})
+                return schema
             else:
                 return {}
 


### PR DESCRIPTION
Paho MQTT supports TLS - this adds the same to the config for dbus2mqtt
