### PR TITLE
Fixed mqtt_message trigger with payload filter

### DIFF
--- a/src/dbus2mqtt/flow/flow_trigger_handlers.py
+++ b/src/dbus2mqtt/flow/flow_trigger_handlers.py
@@ -70,7 +70,8 @@ class FlowTriggerMqttMessageHandler(FlowTriggerHandler):
 
         # mqtt_message triggers might have a filter configured
         if matches and trigger_config.filter is not None:
-            matches = trigger_config.matches_filter(templating, self.context)
+            trigger_context = self.final_trigger_context(trigger_config)
+            matches = trigger_config.matches_filter(templating, trigger_context)
 
         return matches
 

--- a/tests/flow/triggers/test_mqtt_client_triggers.py
+++ b/tests/flow/triggers/test_mqtt_client_triggers.py
@@ -77,7 +77,9 @@ async def test_mqtt_message_trigger_filter_topic():
     test_payload = {
         "action": "test-action",
     }
-    trigger_config = FlowTriggerMqttMessageConfig(topic=test_topic, filter="{{ topic == 'dbus2mqtt/test-topic' }}")
+    trigger_config = FlowTriggerMqttMessageConfig(
+        topic=test_topic, filter="{{ topic == 'dbus2mqtt/test-topic' }}"
+    )
 
     app_context = mocked_app_context()
     _ = _mocked_flow_processor(app_context, trigger_config)
@@ -96,13 +98,17 @@ async def test_mqtt_message_trigger_filter_text_payload():
     test_payload = "online"
     test_json_payload = None
 
-    trigger_config = FlowTriggerMqttMessageConfig(topic=test_topic, content_type=test_content_type, filter="{{ payload == 'online' }}")
+    trigger_config = FlowTriggerMqttMessageConfig(
+        topic=test_topic, content_type=test_content_type, filter="{{ payload == 'online' }}"
+    )
 
     app_context = mocked_app_context()
     _ = _mocked_flow_processor(app_context, trigger_config)
     mqtt_client = mocked_mqtt_client(app_context)
 
-    mqtt_client._trigger_flows(topic=test_topic, payload=test_payload, json_payload=test_json_payload)
+    mqtt_client._trigger_flows(
+        topic=test_topic, payload=test_payload, json_payload=test_json_payload
+    )
 
     assert app_context.event_broker.flow_trigger_queue.sync_q.qsize() == 1
 
@@ -113,17 +119,19 @@ async def test_mqtt_message_trigger_filter_json_payload():
     test_topic = "dbus2mqtt/test-topic"
     test_content_type = "json"
     test_payload = ""
-    test_json_payload = {
-        "status": "online"
-    }
+    test_json_payload = {"status": "online"}
 
-    trigger_config = FlowTriggerMqttMessageConfig(topic=test_topic, content_type=test_content_type, filter="{{ payload.status == 'online' }}")
+    trigger_config = FlowTriggerMqttMessageConfig(
+        topic=test_topic, content_type=test_content_type, filter="{{ payload.status == 'online' }}"
+    )
 
     app_context = mocked_app_context()
     _ = _mocked_flow_processor(app_context, trigger_config)
     mqtt_client = mocked_mqtt_client(app_context)
 
-    mqtt_client._trigger_flows(topic=test_topic, payload=test_payload, json_payload=test_json_payload)
+    mqtt_client._trigger_flows(
+        topic=test_topic, payload=test_payload, json_payload=test_json_payload
+    )
 
     assert app_context.event_broker.flow_trigger_queue.sync_q.qsize() == 1
 

--- a/tests/flow/triggers/test_mqtt_client_triggers.py
+++ b/tests/flow/triggers/test_mqtt_client_triggers.py
@@ -70,6 +70,64 @@ async def test_mqtt_message_trigger_filter_false():
     assert app_context.event_broker.flow_trigger_queue.sync_q.qsize() == 0
 
 
+@pytest.mark.asyncio
+async def test_mqtt_message_trigger_filter_topic():
+
+    test_topic = "dbus2mqtt/test-topic"
+    test_payload = {
+        "action": "test-action",
+    }
+    trigger_config = FlowTriggerMqttMessageConfig(topic=test_topic, filter="{{ topic == 'dbus2mqtt/test-topic' }}")
+
+    app_context = mocked_app_context()
+    _ = _mocked_flow_processor(app_context, trigger_config)
+    mqtt_client = mocked_mqtt_client(app_context)
+
+    mqtt_client._trigger_flows(topic=test_topic, payload="", json_payload=test_payload)
+
+    assert app_context.event_broker.flow_trigger_queue.sync_q.qsize() == 1
+
+
+@pytest.mark.asyncio
+async def test_mqtt_message_trigger_filter_text_payload():
+
+    test_topic = "dbus2mqtt/test-topic"
+    test_content_type = "text"
+    test_payload = "online"
+    test_json_payload = None
+
+    trigger_config = FlowTriggerMqttMessageConfig(topic=test_topic, content_type=test_content_type, filter="{{ payload == 'online' }}")
+
+    app_context = mocked_app_context()
+    _ = _mocked_flow_processor(app_context, trigger_config)
+    mqtt_client = mocked_mqtt_client(app_context)
+
+    mqtt_client._trigger_flows(topic=test_topic, payload=test_payload, json_payload=test_json_payload)
+
+    assert app_context.event_broker.flow_trigger_queue.sync_q.qsize() == 1
+
+
+@pytest.mark.asyncio
+async def test_mqtt_message_trigger_filter_json_payload():
+
+    test_topic = "dbus2mqtt/test-topic"
+    test_content_type = "json"
+    test_payload = ""
+    test_json_payload = {
+        "status": "online"
+    }
+
+    trigger_config = FlowTriggerMqttMessageConfig(topic=test_topic, content_type=test_content_type, filter="{{ payload.status == 'online' }}")
+
+    app_context = mocked_app_context()
+    _ = _mocked_flow_processor(app_context, trigger_config)
+    mqtt_client = mocked_mqtt_client(app_context)
+
+    mqtt_client._trigger_flows(topic=test_topic, payload=test_payload, json_payload=test_json_payload)
+
+    assert app_context.event_broker.flow_trigger_queue.sync_q.qsize() == 1
+
+
 def _mocked_flow_processor(
     app_context: AppContext, trigger_config: FlowTriggerMqttMessageConfig
 ) -> FlowProcessor:


### PR DESCRIPTION
Fix and tests for the following config which caused warnings.

```
WARNING:mqtt_client:_trigger_flows: Error while triggering flow, topic=homeassistant/status, payload=online, error=Error rendering template, template={{ payload == 'online' }}: 'payload' is undefined
```

```yaml
- name: Home Assistant Discovery
  triggers:
    - type: dbus_object_added
    - type: mqtt_message
      topic: homeassistant/status
      content_type: text
      filter: "{{ payload == 'online' }}"
```